### PR TITLE
Fix scrolling problem in msg list

### DIFF
--- a/client.py
+++ b/client.py
@@ -11,6 +11,7 @@ def receive():
         try:
             msg = client_socket.recv(BUFSIZ).decode("utf8")
             msg_list.insert(tkinter.END, msg)
+            msg_list.see(tkinter.END)
         except OSError:  
             break
 


### PR DESCRIPTION
When messages list gets full and more messages are sent,
the scrollbar doesn't go down automatically.
This change fixes it.